### PR TITLE
experiment() - alternative implementation with once + custom listener

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-app",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "license": "MIT",
   "scripts": {
     "build": "rollup -c && workbox injectManifest workbox-config.js",


### PR DESCRIPTION
Less listeners involved this way, but didn't really feel any faster (CPU usage still high on server on initial load). And code is verbose and too complex.

Keeping it open if I ever feel like revisiting this.