### PR TITLE
feature() - use indexed db and latest version of gun

### DIFF
--- a/src/initGun.js
+++ b/src/initGun.js
@@ -1,5 +1,11 @@
 import Gun from "gun/gun";
 import "gun/lib/webrtc";
+import "gun/lib/radix";
+import "gun/lib/radisk";
+import "gun/lib/rindexed";
+// using store doesn't work, fs not supported
+// is this required for indexedDB?
+// import "gun/lib/store";
 
 let peers;
 
@@ -19,6 +25,8 @@ if (process.env.NODE_ENV === "development") {
 
 const gun = new Gun({
   peers,
+  store: RindexedDB(),
+  localStorage: false,
 });
 
 // attaching gun to window for testing purposes

--- a/yarn.lock
+++ b/yarn.lock
@@ -3986,7 +3986,12 @@ trim-newlines@^2.0.0:
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-2.0.0.tgz#b403d0b91be50c331dfc4b82eeceb22c3de16d20"
   integrity sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=
 
-tslib@^1.10.0, tslib@^1.11.1, tslib@^1.9.0:
+tslib@^1.10.0, tslib@^1.11.1, tslib@^1.11.2:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
+  integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
+
+tslib@^1.9.0:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==


### PR DESCRIPTION
This currently has a bug (in indexedDB/gun?) that means you can't use the chat when offline. Keeping this open to see if it gets resolved in new version of gun.